### PR TITLE
Update materialized.js

### DIFF
--- a/lib/materialized.js
+++ b/lib/materialized.js
@@ -35,7 +35,7 @@ function Query(args) {
     this.condition = this.query.condition || {};
     this.fields = this.query.fields || null;
     this.sort = this.query.sort || {};
-    this.limit = this.query.limit || {};
+    this.limit = this.query.limit || undefined;
     this.skip = this.query.skip || 0;
     this.id = this.query.id || null;
 }


### PR DESCRIPTION
empty object {} causes problem with mongodb 3.2 - tries to parse this as a limit